### PR TITLE
FIX mixed content warnings for MathJax

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -33,5 +33,5 @@ layout: default
 
 <!-- mathjax -->
 {% if page.mathjax %}
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 {% endif %}


### PR DESCRIPTION
When I access MathJax enabled pages on your blog (like the neuralnets book) over HTTPS, I get mixed content warnings from Firefox.  MathJax is being included through an "http://" URL.  This patch changes it to a "//" URL, protocol relative.  I haven't tested the change (I don't have Jekyll locally installed), but this should fix it.
