### PR TITLE
Add Atom feed to HTML head for autodiscovery

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    <link href="feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title }} posts" />
 
     <!-- Custom CSS -->
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
Had to manually enter the feed link into my RSS reader, so here's a PR to in theory make autodiscovery work. It is untested, since I didn't want to build your whole site to make sure it worked.