### PR TITLE
Fixing 2 typos

### DIFF
--- a/nntutorial.md
+++ b/nntutorial.md
@@ -746,7 +746,7 @@ var x = Math.max(a, 0)
 var da = a > 0 ? 1.0 * dx : 0.0;
 ```
 
-In other words this gate simply passes the value through if it's larger than 0, or it stops the flow and sets it to zero. In the backward pass, the gate will pass on the gradient from the top if it was activated during the forawrd pass, or if the original input was below zero, it will stop the gradient flow.
+In other words this gate simply passes the value through if it's larger than 0, or it stops the flow and sets it to zero. In the backward pass, the gate will pass on the gradient from the top if it was activated during the forward pass, or if the original input was below zero, it will stop the gradient flow.
 
 I will stop at this point. I hope you got some intuition about how you can compute entire expressions (which are made up of many gates along the way) and how you can compute backprop for every one of them.
 
@@ -936,7 +936,7 @@ for(var iter = 0; iter < 400; iter++) {
   var label = labels[i];
   svm.learnFrom(x, y, label);
 
-  if(iter % 25 == 0) { // every 10 iterations... 
+  if(iter % 25 == 0) { // every 25 iterations... 
     console.log('training accuracy at iter ' + iter + ': ' + evalTrainingAccuracy());
   }
 }


### PR DESCRIPTION
I came along these two typos while reading through the article (thanks a lot for writing it!).
The first is an obvious word typo ("forawrd" instead of "forward"), the second a faulty comment which was likely a forgotten leftover from an earlier code version (the code logs results every 25 iterations according to semantics and example output, not every 10).